### PR TITLE
Change color of h3 elements

### DIFF
--- a/themes/emacs/static/css/main.css
+++ b/themes/emacs/static/css/main.css
@@ -48,11 +48,11 @@ h2 {
 }
 
 h3 {
-	color: #902020; //highlight_red
+	color: #C6B6FE; //highlight_violet
 }
 
 h4 {
-	color: #C6B6FE; //highlight_violet
+	color: #902020; //highlight_red
 }
 
 h5 {


### PR DESCRIPTION
The red color used by the h3 elements was hard to read when applied to
Officer's names.  It should probably be used more for emphasis.  I
exchanged the color for the light violet color which I believe is much
easier on the eyes.
