### PR TITLE
Added homepage to the website.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,18 @@
+
+<!DOCTYPE html>
+<html>
+{{ partial "head.html" . }}
+<body>
+{{ partial "header.html" . }}
+
+<h1 id="welcome-to-clemson-acm">Welcome to Clemson ACM</h1>
+<p>We do cool computing events for cool computing people here at Clemson University. Through out the semester, we put on professional, educational, and community building events. If you want to get involved, you should join our mailing list by contacting <script type="text/javascript">
+<!--
+h='&#x63;&#x73;&#46;&#x63;&#108;&#x65;&#x6d;&#x73;&#x6f;&#110;&#46;&#x65;&#100;&#x75;';a='&#64;';n='&#x61;&#x63;&#x6d;';e=n+a+h;
+document.write('<a h'+'ref'+'="ma'+'ilto'+':'+e+'" clas'+'s="em' + 'ail">'+e+'<\/'+'a'+'>');
+// -->
+</script><noscript>&#x61;&#x63;&#x6d;&#32;&#x61;&#116;&#32;&#x63;&#x73;&#32;&#100;&#x6f;&#116;&#32;&#x63;&#108;&#x65;&#x6d;&#x73;&#x6f;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x65;&#100;&#x75;</noscript>, and checkout our <a href="https://www.google.com/calendar/embed?src=aeh6j0eubfdc3atqq44g7iigu8%40group.calendar.google.com&amp;ctz=America/New_York">calendar</a>.</p>
+
+{{ partial "footer.html" . }}
+</body>
+</html>


### PR DESCRIPTION
Unlike other names, hugo does not allow for a content file to be called
index.md.  The proper means of creating a homepage without overriding
the default index in the theme in hugo is to specify an html file in
`layouts` that is called index.html.  Perhaps there is more elegant way
to generate this page, but this is will work for now.
