### PR TITLE
Missing template error

### DIFF
--- a/themes/emacs/layouts/_default/li.html
+++ b/themes/emacs/layouts/_default/li.html
@@ -1,0 +1,3 @@
+<li>
+<a href="{{ .Permalink }}">{{ .Title }}</a>
+</li>


### PR DESCRIPTION
Previously we generated several error messages that we were missing a file called `li.html` this patch adds one that is essentially a no-op
