### PR TITLE
Add Update Script

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,8 @@
+#!/bin/sh
+git submodule update --init --recursive
+hugo
+find public -name '.git*' -exec rm -rf {} \;
+find public -type d -exec chmod 775 {} \;
+find public -type f -exec chmod 664 {} \;
+find public -exec chown "$USER":coes_acm {} \;
+rsync -av --delete public/ /web/group/acm/htdocs


### PR DESCRIPTION
Add an update script which will build and rsync the latest version of the website to '/web/group/acm/htdocs'. This can be used with a CI system if it is run on the lab machines. This script will make sure permissions are correct to avoid issues like the current one where I can't modify the 'old' folder in the htdocs.
