### PR TITLE
Make baseurl Protocol Independent

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,3 @@
-baseurl = "http://www.cs.clemson.edu/acm"
+baseurl = "//www.cs.clemson.edu/acm"
 title = "Clemson ACM"
 theme = "emacs"


### PR DESCRIPTION
Make the baseurl in config.toml protocol independent to avoid problems when using both http and https.
